### PR TITLE
fix(cli): invert cloudflared flag for better usability

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -43,9 +43,10 @@ const argv = cli({
       description: "The hostname to run the server on.",
     },
 
-    cloudflared: {
+    disableCloudflared: {
       type: Boolean,
-      default: true,
+      alias: "d",
+      default: false,
       description: "Use cloudflared to tunnel the server",
     },
   },
@@ -78,7 +79,7 @@ if (import.meta.main) {
 
   await Promise.all([
     Deno.serve({ port: flags.port, hostname: flags.hostname }, app.fetch),
-    flags.cloudflared &&
+    !flags.disableCloudflared &&
     startTunnel({ port: flags.port, hostname: flags.hostname })
       .then(async (tunnel) => ensure(await tunnel?.getURL(), is.String))
       .then((url) =>


### PR DESCRIPTION
Change the CLI flag from `--cloudflared` (enabled by default) to `--disable-cloudflared` (disabled by default). This provides a more intuitive interface where tunneling is enabled by default, and users can opt out with the new flag.

Add an alias `-d` for quicker command-line use.

fixes: https://github.com/ryoppippi/curxy/issues/33

This pull request includes changes to the `main.ts` file to modify the handling of the cloudflared tunneling option. The key changes involve renaming and altering the default behavior of the cloudflared option.

Changes to cloudflared option:

* [`main.ts`](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L46-R49): Renamed the `cloudflared` option to `disableCloudflared`, changed its type to Boolean, added an alias "d", and set the default to false.
* [`main.ts`](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L81-R82): Updated the conditional logic to use `!flags.disableCloudflared` instead of `flags.cloudflared` when starting the tunnel.